### PR TITLE
Trigger OnGhostDrop when dropping ghost.

### DIFF
--- a/scripting/nt_anti_ghosthop.sp
+++ b/scripting/nt_anti_ghosthop.sp
@@ -64,6 +64,8 @@ static float _freefall_velocity;
 static bool _freefalling = false;
 // Handle for tracking the grace period reset timer
 static Handle _timer_reset_gp = INVALID_HANDLE;
+// To manually trigger OnGhostDrop event
+static Handle g_hForwardDrop;
 
 static ConVar _cvar_gravity;
 
@@ -129,6 +131,7 @@ public void OnAllPluginsLoaded()
     {
         SetFailState("This plugin requires the nt_ghostcap plugin");
     }
+    g_hForwardDrop = CreateGlobalForward("OnGhostDrop", ET_Event, Param_Cell);
 }
 
 public void OnMapEnd()
@@ -319,6 +322,9 @@ public void OnPlayerRunCmdPost(int client, int buttons, int impulse,
             {
                 SDKHooks_DropWeapon(client, ghost, ghoster_pos, NULL_VECTOR);
                 PrintToChat(client, "%s You have dropped the ghost (jumping faster than ghost carry speed)", PLUGIN_TAG);
+                Call_StartForward(g_hForwardDrop);
+                Call_PushCell(client);
+                Call_Finish();
             }
             // We had a ghoster userid, and the ghost exists, but that supposed ghoster no longer holds the ghost.
             // This can happen if the ghoster is ghost hopping exactly as the round ends and the ghost de-spawns.

--- a/scripting/nt_anti_ghosthop.sp
+++ b/scripting/nt_anti_ghosthop.sp
@@ -16,7 +16,7 @@
 Profiler _profiler = null;
 #endif
 
-#define PLUGIN_VERSION "0.11.1"
+#define PLUGIN_VERSION "0.12.0"
 #define PLUGIN_TAG "[ANTI-GHOSTHOP]"
 #define NEO_MAXPLAYERS 32
 


### PR DESCRIPTION
Dropping the ghost with SDKHooks_DropWeapon doesn't seem to trigger the SDKHook_WeaponDropPost hook used by the nt_ghostcap plugin, so instead I'm calling OnGhostDrop manually.

I know this is super ugly, so please let me know if you have better idea of how to solve this.