### PR TITLE
Drop SM 1.8 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Thanks for attending my ted talk.
 ## More info for server operators
 
 ### Build requirements
-* SourceMod version 1.8 or newer
+* SourceMod version 1.9 or newer
 * The [Neotokyo include](https://github.com/softashell/sourcemod-nt-include) .inc file (place inside <i>scripting/includes</i>)
 
 ### Troubleshooting

--- a/scripting/nt_anti_ghosthop.sp
+++ b/scripting/nt_anti_ghosthop.sp
@@ -1,3 +1,8 @@
+#if SOURCEMOD_V_MAJOR <= 1 && SOURCEMOD_V_MINOR < 9
+// Because we require OnPlayerRunCmdPost, which was added in 1.9.
+#error This plugin does not support SourceMod older than 1.9
+#endif
+
 #pragma semicolon 1
 
 #include <sourcemod>


### PR DESCRIPTION
While this plugin does compile on SM 1.7 and 1.8, the OnPlayerRunCmdPost function was only added in SM 1.9, so we have to drop support for versions <1.9, at least for now.